### PR TITLE
Fixed false positives and new feature for multiple matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Select any function and press your assigned keybind, and Sigga's UI should pop u
 
 ![](https://i.imgur.com/mVA2oPr.png)
 
-![](https://i.imgur.com/HfhQFxi.png)
+![](https://i.imgur.com/Z4AOOIW.png)
 
 ## Contributing/Bug reporting
 
@@ -51,3 +51,4 @@ Feel free to open a pull request, but please make sure your changes/new code are
 
 - ~~Currently, the way I am placing wildcards is suboptimal. It may wildcard more instructions then actually needed.~~ Fixed by @outercloudstudio
 - Sometimes it can't find specific signatures. This seems to be a bug in ghidra.
+- Progress not working correctly, stays at 0%.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Feel free to open a pull request, but please make sure your changes/new code are
 
 ## Known bugs/Issues
 
-- Progress indicator not working correctly, stays at 0%.
+- None


### PR DESCRIPTION
# False Positives

While reversing engineering two similar executables, I noticed that when searching for signatures, and that signature was not present in the target file, Sigga would return a false positive, so basically a random address that had no correlation with the signature.
After some testing, I noticed that the issue came from the following code inside findAddressForSignature:
```java
// Try to find the signature
return currentProgram.getMemory().findBytes(currentProgram.getMinAddress(), currentProgram.getMaxAddress(),
        byteSignature.getBytes(), byteSignature.getMask(), true, monitor);
```
I verified that the pattern and the mask were correct. However, for some unknown reason, findBytes was returning a false address.
\
So I implemented a manual version of findBytes that still uses findBytes, but only to look for an anchor, a sequence of bytes without wildcards. This way findBytes doesn't require a mask and no false positives are returned.

# Multiple matches

Instead or returning the first occurrence of the signature, I changed to code to return all matches which is more useful.
\
I could also change the script, so that finding multiple matches is a separate feature
                